### PR TITLE
Replaced deprecated function

### DIFF
--- a/src/Downloader.cpp
+++ b/src/Downloader.cpp
@@ -123,7 +123,7 @@ void Downloader::startDownload(const QUrl &url)
 
    /* Start download */
    m_reply = m_manager->get(request);
-   m_startTime = QDateTime::currentDateTime().toTime_t();
+   m_startTime = QDateTime::currentDateTime().toSecsSinceEpoch();
 
    /* Ensure that downloads directory exists */
    if (!m_downloadDir.exists())
@@ -375,7 +375,7 @@ void Downloader::updateProgress(qint64 received, qint64 total)
  */
 void Downloader::calculateTimeRemaining(qint64 received, qint64 total)
 {
-   uint difference = QDateTime::currentDateTime().toTime_t() - m_startTime;
+   uint difference = QDateTime::currentDateTime().toSecsSinceEpoch(); - m_startTime;
 
    if (difference > 0)
    {


### PR DESCRIPTION
On lines 126 and 378 of the Downloader.cpp source file obsolete function `uint QDateTime::toTime_t() const` is used. [See documentation](https://doc.qt.io/qt-5/qdatetime-obsolete.html#toTime_t).
This gives an error when building on Qt6, so I replaced it with `qint64 QDateTime::toSecsSinceEpoch() const`. [See documentation](https://doc.qt.io/qt-5/qdatetime.html#toSecsSinceEpoch).
Also, used [this](https://stackoverflow.com/questions/2781119/how-to-get-the-current-timestamp#comment104756784_2781409) as a reference.

`m_startTime = QDateTime::currentDateTime().toTime_t();`
now looks like
`m_startTime = QDateTime::currentDateTime().toSecsSinceEpoch();`

and

`uint difference = QDateTime::currentDateTime().toTime_t() - m_startTime;`
now looks like
`m_startTime = QDateTime::currentDateTime().toSecsSinceEpoch() - m_startTime;`

hence fixing the `‘class QDateTime’ has no member named ‘toTime_t’; did you mean ‘toTimeSpec’?` error.

For reference, the whole error log is as follows:
```
/home/clara/Documents/Projects/UpdatesTest/3rdparty/QSimpleUpdater/src/Downloader.cpp:126: error: ‘class QDateTime’ has no member named ‘toTime_t’; did you mean ‘toTimeSpec’?
../UpdatesTest/3rdparty/QSimpleUpdater/src/Downloader.cpp: In member function ‘void Downloader::startDownload(const QUrl&)’:
../UpdatesTest/3rdparty/QSimpleUpdater/src/Downloader.cpp:126:47: error: ‘class QDateTime’ has no member named ‘toTime_t’; did you mean ‘toTimeSpec’?
  126 |    m_startTime = QDateTime::currentDateTime().toTime_t();
      |                                               ^~~~~~~~
      |                                               toTimeSpec

/home/clara/Documents/Projects/UpdatesTest/3rdparty/QSimpleUpdater/src/Downloader.cpp:378: error: ‘class QDateTime’ has no member named ‘toTime_t’; did you mean ‘toTimeSpec’?
../UpdatesTest/3rdparty/QSimpleUpdater/src/Downloader.cpp: In member function ‘void Downloader::calculateTimeRemaining(qint64, qint64)’:
../UpdatesTest/3rdparty/QSimpleUpdater/src/Downloader.cpp:378:51: error: ‘class QDateTime’ has no member named ‘toTime_t’; did you mean ‘toTimeSpec’?
  378 |    uint difference = QDateTime::currentDateTime().toTime_t() - m_startTime;
      |                                                   ^~~~~~~~
      |                                                   toTimeSpec
```

Tested on Linux with the tutorial project on the repo and it works fine :)