### PR TITLE
Properly follow HTTP redirects

### DIFF
--- a/src/Downloader.cpp
+++ b/src/Downloader.cpp
@@ -110,6 +110,9 @@ void Downloader::startDownload(const QUrl &url)
 
    /* Configure the network request */
    QNetworkRequest request(url);
+
+   request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+
    if (!m_userAgentString.isEmpty())
       request.setRawHeader("User-Agent", m_userAgentString.toUtf8());
 
@@ -128,7 +131,6 @@ void Downloader::startDownload(const QUrl &url)
    /* Update UI when download progress changes or download finishes */
    connect(m_reply, SIGNAL(downloadProgress(qint64, qint64)), this, SLOT(updateProgress(qint64, qint64)));
    connect(m_reply, SIGNAL(finished()), this, SLOT(finished()));
-   connect(m_reply, SIGNAL(redirected(QUrl)), this, SLOT(startDownload(QUrl)));
 
    showNormal();
 }

--- a/src/Updater.cpp
+++ b/src/Updater.cpp
@@ -234,6 +234,9 @@ bool Updater::useCustomInstallProcedures() const
 void Updater::checkForUpdates()
 {
    QNetworkRequest request(url());
+
+   request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+
    if (!userAgentString().isEmpty())
       request.setRawHeader("User-Agent", userAgentString().toUtf8());
 


### PR DESCRIPTION
Closes #29, Closes #26

To test this I had make some changes to the tutorial project.

- Update the DEFS_URL to a local file, e.g. `"file:///C:/projects/QSimpleUpdater/tutorial/definitions/updates.json"`
- Also modified the "updates.json" `download-url` to a URL that causes a redirect, e.g. https://github.com/dail8859/NotepadNext/releases/download/v0.4.1/NotepadNext-v0.4.1-Installer.exe

Once those changes are made then bug is apparent. The download instantly finishes, ends up with a 0 byte file, and presented multilpe times with the "Click OK to begin installation" message.

After this patch is applied the application behaves as expected.

---

To be fair I really have no experience with Qt networking at all so someone may have more experience or insight.