### PR TITLE
fix: set timeout

### DIFF
--- a/src/Downloader.cpp
+++ b/src/Downloader.cpp
@@ -114,6 +114,11 @@ void Downloader::startDownload(const QUrl &url)
    QNetworkRequest request(url);
 
    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+   
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+   /* 10s timeout */
+   request.setTransferTimeout(10000);
+#endif
 
    if (!m_userAgentString.isEmpty())
       request.setRawHeader("User-Agent", m_userAgentString.toUtf8());


### PR DESCRIPTION
If the network is interrupted, the download status will never be updated. So set a default timeout of 10s.

Closes #40