### PR TITLE
Feature : Add CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.3)
+project(QSimpleUpdater
+    LANGUAGES CXX
+)
+
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOMOC ON)
+
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets Network)
+find_package(Qt${QT_VERSION_MAJOR} CONFIG REQUIRED COMPONENTS Widgets Network)
+
+add_library(QSimpleUpdater STATIC
+    etc/resources/qsimpleupdater.qrc
+    include/QSimpleUpdater.h
+    src/Downloader.cpp
+    src/Downloader.h
+    src/Downloader.ui
+    src/QSimpleUpdater.cpp
+    src/Updater.cpp
+    src/Updater.h
+)
+target_include_directories(QSimpleUpdater PUBLIC include)
+target_link_libraries(QSimpleUpdater PUBLIC Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets PRIVATE Qt${QT_VERSION_MAJOR}::Network)
+
+add_subdirectory(tutorial)

--- a/tutorial/CMakeLists.txt
+++ b/tutorial/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(QSU_Tutorial
+    LANGUAGES CXX
+)
+
+add_executable(QSU_Tutorial WIN32 MACOSX_BUNDLE EXCLUDE_FROM_ALL
+    src/Window.ui
+    src/Window.h
+    src/Window.cpp
+    src/main.cpp
+)
+target_compile_definitions(QSimpleUpdater PUBLIC QSU_INCLUDE_MOC)
+target_link_libraries(QSU_Tutorial QSimpleUpdater)


### PR DESCRIPTION
Hi, this is the first patch of a series of features we added to the library internally. Happy to rework as you would want it merged.

This patch adds CMake support for the library and the tutorial example.

* Pick Qt6/Qt5 depending on availability
* added CMake build for `tutorial`