### PR TITLE
Semantic versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets Network)
-find_package(Qt${QT_VERSION_MAJOR} CONFIG REQUIRED COMPONENTS Widgets Network)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets Network Test)
+find_package(Qt${QT_VERSION_MAJOR} CONFIG REQUIRED COMPONENTS Widgets Network Test)
 
 add_library(QSimpleUpdater STATIC
     etc/resources/qsimpleupdater.qrc
@@ -27,3 +27,15 @@ target_include_directories(QSimpleUpdater PUBLIC include)
 target_link_libraries(QSimpleUpdater PUBLIC Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets PRIVATE Qt${QT_VERSION_MAJOR}::Network)
 
 add_subdirectory(tutorial)
+
+
+enable_testing()
+add_executable(UnitTests
+    tests/main.cpp
+    tests/Test_Versioning.h
+    tests/Test_Updater.h
+    tests/Test_QSimpleUpdater.h
+    tests/Test_Downloader.h
+)
+add_test(NAME ApiTest COMMAND ApiTest)
+target_link_libraries(UnitTests PRIVATE Qt${QT_VERSION_MAJOR}::Test QSimpleUpdater)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,18 @@ project(QSimpleUpdater
     LANGUAGES CXX
 )
 
+option(QSIMPLE_UPDATER_BUILD_TESTS "Build the unit tests" ON)
+
 set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets Network Test)
-find_package(Qt${QT_VERSION_MAJOR} CONFIG REQUIRED COMPONENTS Widgets Network Test)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets Network)
+find_package(Qt${QT_VERSION_MAJOR} CONFIG REQUIRED COMPONENTS Widgets Network)
+
+if(QSIMPLE_UPDATER_BUILD_TESTS)
+    find_package(Qt${QT_VERSION_MAJOR} CONFIG REQUIRED COMPONENTS Test)
+endif()
 
 add_library(QSimpleUpdater STATIC
     etc/resources/qsimpleupdater.qrc
@@ -28,14 +34,15 @@ target_link_libraries(QSimpleUpdater PUBLIC Qt${QT_VERSION_MAJOR}::Core Qt${QT_V
 
 add_subdirectory(tutorial)
 
-
-enable_testing()
-add_executable(UnitTests
-    tests/main.cpp
-    tests/Test_Versioning.h
-    tests/Test_Updater.h
-    tests/Test_QSimpleUpdater.h
-    tests/Test_Downloader.h
-)
-add_test(NAME ApiTest COMMAND ApiTest)
-target_link_libraries(UnitTests PRIVATE Qt${QT_VERSION_MAJOR}::Test QSimpleUpdater)
+if(QSIMPLE_UPDATER_BUILD_TESTS)
+    enable_testing()
+    add_executable(UnitTests
+        tests/main.cpp
+        tests/Test_Versioning.h
+        tests/Test_Updater.h
+        tests/Test_QSimpleUpdater.h
+        tests/Test_Downloader.h
+    )
+    add_test(NAME ApiTest COMMAND ApiTest)
+    target_link_libraries(UnitTests PRIVATE Qt${QT_VERSION_MAJOR}::Test QSimpleUpdater)
+endif()

--- a/include/QSimpleUpdater.h
+++ b/include/QSimpleUpdater.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2014-2021 Alex Spataru <https://github.com/alex-spataru>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -67,6 +67,7 @@ signals:
 
 public:
    static QSimpleUpdater *getInstance();
+   static bool compareVersions(const QString &remote, const QString &local);
 
    bool usesCustomAppcast(const QString &url) const;
    bool getNotifyOnUpdate(const QString &url) const;

--- a/src/QSimpleUpdater.cpp
+++ b/src/QSimpleUpdater.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2014-2021 Alex Spataru <https://github.com/alex-spataru>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -20,8 +20,9 @@
  * THE SOFTWARE.
  */
 
-#include "Updater.h"
 #include "QSimpleUpdater.h"
+#include "Updater.h"
+#include <qregularexpression.h>
 
 static QList<QString> URLS;
 static QList<Updater *> UPDATERS;
@@ -43,6 +44,47 @@ QSimpleUpdater *QSimpleUpdater::getInstance()
 {
    static QSimpleUpdater updater;
    return &updater;
+}
+
+bool QSimpleUpdater::compareVersions(const QString &remote, const QString &local)
+{
+   static QRegularExpression re("v?(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:-(\\w+)(?:(\\d+))?)?");
+   QRegularExpressionMatch remoteMatch = re.match(remote);
+   QRegularExpressionMatch localMatch = re.match(local);
+
+   if (!remoteMatch.hasMatch() || !localMatch.hasMatch())
+   {
+      // Invalid version format
+      return false;
+   }
+
+   for (int i = 1; i <= 3; ++i)
+   {
+      int remoteNum = remoteMatch.captured(i).toInt();
+      int localNum = localMatch.captured(i).toInt();
+
+      if (remoteNum > localNum)
+         return true;
+      else if (localNum > remoteNum)
+         return false;
+   }
+
+   QString remoteSuffix = remoteMatch.captured(4);
+   QString localSuffix = localMatch.captured(4);
+
+   if (remoteSuffix.isEmpty() && !localSuffix.isEmpty())
+      // Remote is stable, local is pre-release
+      return true;
+   if (!remoteSuffix.isEmpty() && localSuffix.isEmpty())
+      // Remote is pre-release, local is stable
+      return false;
+   if (remoteSuffix != localSuffix)
+      // Compare suffixes lexicographically
+      return remoteSuffix > localSuffix;
+
+   int remoteSuffixNum = remoteMatch.captured(5).toInt();
+   int localSuffixNum = localMatch.captured(5).toInt();
+   return remoteSuffixNum > localSuffixNum;
 }
 
 /**

--- a/src/Updater.cpp
+++ b/src/Updater.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2014-2021 Alex Spataru <https://github.com/alex-spataru>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -511,24 +511,7 @@ void Updater::setUpdateAvailable(const bool available)
  */
 bool Updater::compare(const QString &x, const QString &y)
 {
-   QStringList versionsX = x.split(".");
-   QStringList versionsY = y.split(".");
-
-   int count = qMin(versionsX.count(), versionsY.count());
-
-   for (int i = 0; i < count; ++i)
-   {
-      int a = QString(versionsX.at(i)).toInt();
-      int b = QString(versionsY.at(i)).toInt();
-
-      if (a > b)
-         return true;
-
-      else if (b > a)
-         return false;
-   }
-
-   return versionsY.count() < versionsX.count();
+   return QSimpleUpdater::compareVersions(x, y);
 }
 
 #if QSU_INCLUDE_MOC

--- a/tests/Test_Downloader.h
+++ b/tests/Test_Downloader.h
@@ -24,7 +24,6 @@
 #define TEST_DOWNLOADER_H
 
 #include <QtTest>
-#include <Downloader.h>
 
 class Test_Downloader : public QObject
 {

--- a/tests/Test_Updater.h
+++ b/tests/Test_Updater.h
@@ -20,15 +20,12 @@
  * THE SOFTWARE.
  */
 
-#ifndef TEST_UPDATER_H
-#define TEST_UPDATER_H
+#pragma once
 
 #include <QtTest>
-#include <Updater.h>
+#include <QSimpleUpdater.h>
 
 class Test_Updater : public QObject
 {
    Q_OBJECT
 };
-
-#endif

--- a/tests/Test_Versioning.h
+++ b/tests/Test_Versioning.h
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2015-2016 Alex Spataru <alex_spataru@outlook.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#pragma once
+
+#include <QtTest>
+#include <QSimpleUpdater.h>
+
+class Test_Versioning : public QObject
+{
+   Q_OBJECT
+private slots:
+   void TestPrefixSameVersion()
+   {
+      bool needsUpgrade;
+      needsUpgrade = QSimpleUpdater::compareVersions("0.0.1", "0.0.1");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("0.0.1", "v0.0.1");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.0.1", "0.0.1");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.0.1", "v0.0.1");
+      QVERIFY(!needsUpgrade);
+   }
+
+   void MajorMinorRelease()
+   {
+      bool needsUpgrade;
+
+      // Note how "v" is prefixed in different version, this should not
+      // matter to us
+      needsUpgrade = QSimpleUpdater::compareVersions("0.0.2", "0.0.1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("0.0.2", "v0.0.1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.0.2", "0.0.1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.0.2", "v0.0.1");
+      QVERIFY(needsUpgrade);
+
+      // Revisions are treated as numbers, and not text
+      needsUpgrade = QSimpleUpdater::compareVersions("0.0.8", "0.0.2");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("0.0.8", "v0.0.2");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.0.9", "0.0.8");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.0.8", "v0.0.2");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.0.8", "v0.0.2");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.0.12", "v0.0.2");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.0.112", "v0.0.2");
+      QVERIFY(needsUpgrade);
+
+      // Minor versions test
+      needsUpgrade = QSimpleUpdater::compareVersions("0.1.2", "0.0.8");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("0.1.2", "v0.0.8");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.1.2", "0.0.8");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.1.2", "v0.0.8");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("0.0.8", "0.1.2");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.0.8", "0.1.2");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("0.0.8", "v0.1.2");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v0.0.8", "v0.1.2");
+      QVERIFY(!needsUpgrade);
+
+      // Major versions test
+      needsUpgrade = QSimpleUpdater::compareVersions("1.0.2", "0.9.8");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("1.1.2", "v0.7.8");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v2.0.2", "1.9.8");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v100.2$.2", "v100.1.8");
+      QVERIFY(needsUpgrade);
+   }
+
+   void AlphaVersions()
+   {
+      bool needsUpgrade;
+
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-alpha2", "v1.0.0-alpha1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-alpha10", "v1.0.0-alpha1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-alpha1", "v1.0.0-alpha2");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-alpha1", "v1.0.0-alpha19");
+      QVERIFY(!needsUpgrade);
+
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0", "v1.0.0-alpha1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0", "v1.0.0-alpha10");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0", "v1.0.0-alpha18");
+      QVERIFY(needsUpgrade);
+
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-alpha1", "v1.0.0");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-alpha1000", "v1.0.0");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-alpha88", "v1.0.0");
+      QVERIFY(!needsUpgrade);
+   }
+
+   void BetaVersions()
+   {
+      bool needsUpgrade;
+
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-beta", "v1.0.0-alpha1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-beta2", "v1.0.0-alpha1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-beta0", "v1.0.0-alpha1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-alpha1", "v1.0.0-beta2");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-alpha9999", "v1.0.0-beta19");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-beta2", "v1.0.0-alpha1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-beta19", "v1.0.0-alpha9999");
+      QVERIFY(needsUpgrade);
+
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0", "v1.0.0-beta0");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0", "v1.0.0-beta1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0", "v0.1.0-beta9999");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0", "v2.0.0-beta9999");
+      QVERIFY(!needsUpgrade);
+   }
+
+   void RemoteCandidateVersions()
+   {
+      bool needsUpgrade;
+
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0", "v1.0.0-rc");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0", "v1.0.0-rc1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-rc1", "v1.0.0-rc1");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-rc2", "v1.0.0-rc1");
+      QVERIFY(needsUpgrade);
+
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-rc1", "v1.0.0-alpha1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-rc1", "v1.0.0-alpha200");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-rc1", "v1.0.0-beta1");
+      QVERIFY(needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-rc1", "v1.0.0-beta2000");
+      QVERIFY(needsUpgrade);
+
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-alpha1", "v1.0.0-rc1");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-alpha200", "v1.0.0-rc1");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-beta1", "v1.0.0-rc1");
+      QVERIFY(!needsUpgrade);
+      needsUpgrade = QSimpleUpdater::compareVersions("v1.0.0-beta2000", "v1.0.0-rc1");
+      QVERIFY(!needsUpgrade);
+   }
+};

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -37,10 +37,27 @@ int main(int argc, char *argv[])
 {
    int status = 0;
 
-   runTest(Test_Versioning);
-   runTest(Test_Updater);
-   runTest(Test_Downloader);
-   runTest(Test_QSimpleUpdater);
+   // runTest(Test_Versioning);
+   // runTest(Test_Updater);
+   // runTest(Test_Downloader);
+   // runTest(Test_QSimpleUpdater);
+
+   {
+      Test_Versioning tt;
+      status |= QTest::qExec(&tt, argc, argv);
+   }
+   {
+      Test_Updater tt;
+      status |= QTest::qExec(&tt, argc, argv);
+   }
+   {
+      Test_Downloader tt;
+      status |= QTest::qExec(&tt, argc, argv);
+   }
+   {
+      Test_QSimpleUpdater tt;
+      status |= QTest::qExec(&tt, argc, argv);
+   }
 
    return status;
 }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -20,22 +20,27 @@
  * THE SOFTWARE.
  */
 
+#include <QTest>
+#include <QSimpleUpdater.h>
+#include "Test_Versioning.h"
 #include "Test_Updater.h"
 #include "Test_Downloader.h"
 #include "Test_QSimpleUpdater.h"
 
+#define runTest(T)                                                                                                     \
+   {                                                                                                                   \
+      T tt;                                                                                                            \
+      status |= QTest::qExec(&tt, argc, argv);                                                                         \
+   }
+
 int main(int argc, char *argv[])
 {
-   QApplication app(argc, argv);
+   int status = 0;
 
-   app.setApplicationName("QSimpleUpdater Tests");
-   app.setOrganizationName("The QSimpleUpdater Library");
+   runTest(Test_Versioning);
+   runTest(Test_Updater);
+   runTest(Test_Downloader);
+   runTest(Test_QSimpleUpdater);
 
-   QTest::qExec(new Test_Updater, argc, argv);
-   QTest::qExec(new Test_Downloader, argc, argv);
-   QTest::qExec(new Test_QSimpleUpdater, argc, argv);
-
-   QTimer::singleShot(1000, Qt::PreciseTimer, qApp, SLOT(quit()));
-
-   return app.exec();
+   return status;
 }


### PR DESCRIPTION
Add support for semantic version... and more
Made a new public API, the function that compares versions, moved from
Updater to `QSimpleUpdater` as a static method. I also moved improved (*)
the method to support more of semantic versioning:

1. you can have a optional "v" prefix. Lower case, I am doing this on
purpose. Because.
2. I added support for `-alpha*` `-beta*` and `-rc*` sub versioning.
`beta` wins `alpha`, `rc` wins `beta` and no prefix wins `rc`.

I also added extensive unit testing to this feature. Since the unit
testing was actually MIA - I ported it to Qt6, and added it to the
CMake.

I am not dealing with the other parts of the unit testing - but I assume
"someone" will be able to pick up where I left it. At least the
versioning part is covered.

Why not using Qt classes? See also https://github.com/alex-spataru/QSimpleUpdater/pull/17 I am also unsure if they properly support rc/alpha logic I added.

Ideally - all not part of the scope of this PR:

- This library would have a way for me as a consumer of the code, to tell you "here is my comperator class", and I could put https://github.com/Neargye/semver . 
- Another alternative - is to have *semver* as an internal class in this library, a static copy. 
- Github actions to unit-test the library would be cool. 

This PR can be squashed upon request.

![image](https://github.com/user-attachments/assets/f0daabdd-2c5e-4caf-9a0e-0bb4f0a2a658)