### PR TITLE
Raise minimum CMake version to support CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 project(QSimpleUpdater
     LANGUAGES CXX
 )


### PR DESCRIPTION
CMake version 4 remove compatibility for CMake < 3.5

But in CMake 3.31.3, there was already a message for removing compatibility for CMake < 3.10:
```
CMake Deprecation Warning at 3rdparty/vcpkg/scripts/buildsystems/vcpkg.cmake:40 (cmake_policy):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
```

Set the minimum version to CMake 3.10 (released 7.5 years ago)